### PR TITLE
feat: optionally use GTDB taxonomy for prokaryotes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ wheels/
 
 # Taxonomy db
 taxonomy.db
+taxonomy_ncbi_and_gtdb.db

--- a/src/taxonomy_tree/taxonomy.py
+++ b/src/taxonomy_tree/taxonomy.py
@@ -217,9 +217,10 @@ class Taxonomy:
 
         # create a root node for the GTDB taxonomy and anchor it to the root of the NCBI taxonomy
         gtdb_root = f"{db_prefix}:root"
+        ncbi_tax_root_node = "1"  # NCBI taxonomy defines the root node with taxid 1
         db.execute(
             "INSERT INTO nodes (taxid, parent_taxid, rank) VALUES (?, ?, ?)",
-            (gtdb_root, "0", "no rank"),
+            (gtdb_root, ncbi_tax_root_node, "no rank"),
         )
         db.execute(
             "INSERT INTO names (taxid, scientific_name) VALUES (?, ?)",

--- a/src/taxonomy_tree/taxonomy.py
+++ b/src/taxonomy_tree/taxonomy.py
@@ -201,6 +201,7 @@ class Taxonomy:
         versioning scheme defined at https://gtdb.ecogenomic.org/faq#what-is-the-gtdb-versioning-scheme. The version
         can be found at the RELEASE_NOTES.txt of the GTDB release, e.g. at
         https://data.ace.uq.edu.au/public/gtdb/data/releases/release226/226.0/RELEASE_NOTES.txt.
+        :param db_prefix: The prefix to use for the GTDB taxids in the database, by default "gtdb".
         :return:
         """
         # check version

--- a/src/taxonomy_tree/taxonomy.py
+++ b/src/taxonomy_tree/taxonomy.py
@@ -219,9 +219,21 @@ class Taxonomy:
         # create a root node for the GTDB taxonomy and anchor it to the root of the NCBI taxonomy
         gtdb_root = f"{db_prefix}:root"
         ncbi_tax_root_node = "1"  # NCBI taxonomy defines the root node with taxid 1
+
+        # ensure NCBI root node exists in the nodes table
+        node_1 = db.execute(
+            "SELECT taxid FROM nodes WHERE taxid = ?",
+            (ncbi_tax_root_node,),
+        ).fetchone()
+        if node_1 is None:
+            raise ValueError(
+                f"NCBI root node with taxid {ncbi_tax_root_node} not found in the nodes table. "
+                "Please ensure the NCBI taxonomy has been loaded before adding GTDB taxonomy."
+            )
+
         db.execute(
             "INSERT INTO nodes (taxid, parent_taxid, rank) VALUES (?, ?, ?)",
-            (gtdb_root, ncbi_tax_root_node, "no rank"),
+            (gtdb_root, ncbi_tax_root_node, "cellular root"),
         )
         db.execute(
             "INSERT INTO names (taxid, scientific_name) VALUES (?, ?)",

--- a/src/taxonomy_tree/taxonomy.py
+++ b/src/taxonomy_tree/taxonomy.py
@@ -172,8 +172,6 @@ class Taxonomy:
             print(f"Loaded {len(assemblies_df)} assemblies")
 
             # Optionally load prokaryotic taxonomy from the Genome Taxonomy Database (GTDB)
-            # This overwrites the taxonomy for prokaryotes in the assemblies table when they are in GTDB and links them
-            # to the GTDB taxonomy.
             if add_gtdb_taxonomy:
                 self._add_gtdb_taxonomy(db, tmpdirname)
 

--- a/tests/test_taxonomy.py
+++ b/tests/test_taxonomy.py
@@ -21,6 +21,18 @@ def taxonomy() -> Taxonomy:
     return taxonomy
 
 
+@pytest.fixture()
+def taxonomy_ncbi_and_gtdb() -> Taxonomy:
+    path = Path("taxonomy_ncbi_and_gtdb.db")
+    taxonomy = Taxonomy(path)
+    if not path.exists():
+        print("Creating taxonomy database")
+        taxonomy.create_db(
+            add_gtdb_taxonomy=True,
+        )
+    return taxonomy
+
+
 def test_pickle(taxonomy: Taxonomy) -> None:
     assert taxonomy.contains(HUMAN_ASSEMBLY)
     taxonomy2: Taxonomy = pickle.loads(pickle.dumps(taxonomy))
@@ -30,6 +42,17 @@ def test_pickle(taxonomy: Taxonomy) -> None:
 def test_scientific_name(taxonomy: Taxonomy) -> None:
     scientific_name = taxonomy.find_scientific_name(HUMAN_TAXID)
     assert scientific_name == HUMAN_NAME
+
+
+def test_scientific_name_gtdb(taxonomy_ncbi_and_gtdb: Taxonomy) -> None:
+    scientific_name = taxonomy_ncbi_and_gtdb.find_scientific_name("RS_GCF_009898805.1")
+    assert scientific_name == "Escherichia coli"
+    scientific_name = taxonomy_ncbi_and_gtdb.find_scientific_name("GB_GCA_036518755.1")
+    assert scientific_name == "Palsa-295 sp036518755"
+    scientific_name = taxonomy_ncbi_and_gtdb.find_scientific_name("RS_GCF_959018705.1")
+    assert scientific_name == "Methanocatella smithii"
+    scientific_name = taxonomy_ncbi_and_gtdb.find_scientific_name("GB_GCA_008080825.1")
+    assert scientific_name == "MGIIb-O2 sp002686525"
 
 
 def test_lineage(taxonomy: Taxonomy) -> None:
@@ -46,11 +69,47 @@ def test_lineage(taxonomy: Taxonomy) -> None:
     assert index == len(identifiers) - 1, "40674 not last in lineage despite being the stop rank."
 
 
+def test_lineage_gtdb(taxonomy_ncbi_and_gtdb: Taxonomy) -> None:
+    lineage = list(taxonomy_ncbi_and_gtdb.find_lineage("RS_GCF_000744315.1", stop_rank="class"))
+    assert all(isinstance(entry, TaxonomyEntry) for entry in lineage)
+    identifiers = [entry.identifier for entry in lineage]
+    assert "gtdb:d__Archaea" not in identifiers, (
+        "gtdb:d__Archaea in lineage although beyond stop rank."
+    )
+    expected = [
+        "RS_GCF_000744315.1",
+        "gtdb:s__Methanosarcina mazei",
+        "gtdb:g__Methanosarcina",
+        "gtdb:f__Methanosarcinaceae",
+        "gtdb:o__Methanosarcinales",
+        "gtdb:c__Methanosarcinia",
+    ]
+    index = -1
+    for identifier in expected:
+        find = identifiers.index(identifier)
+        assert find > index, f"Identifier {identifier} not in correct order."
+        index = find
+    assert index == len(identifiers) - 1, (
+        "gtdb:c__Methanosarcinia not last in lineage despite being the stop rank."
+    )
+
+
 def test_children(taxonomy: Taxonomy) -> None:
     children = list(taxonomy.find_children("9604"))
     identifiers = {child.identifier for child in children}
     assert HUMAN_ASSEMBLY in identifiers, "Human assembly not in children of 9604."
     assert HUMAN_TAXID in identifiers, "Human taxid not in children of 9604."
+
+
+def test_children_gtdb(taxonomy_ncbi_and_gtdb: Taxonomy) -> None:
+    children = list(taxonomy_ncbi_and_gtdb.find_children("gtdb:o__Acidiferrobacterales"))
+    identifiers = {child.identifier for child in children}
+    assert "GB_GCA_035292245.1" in identifiers, (
+        "GB_GCA_035292245.1 assembly not in children of gtdb:o__Acidiferrobacterales."
+    )
+    assert "gtdb:f__SPGG2" in identifiers, (
+        "gtdb:f__SPGG2 taxid not in children of gtdb:o__Acidiferrobacterales."
+    )
 
 
 def test_nearest_neighbor(taxonomy: Taxonomy) -> None:

--- a/tests/test_taxonomy.py
+++ b/tests/test_taxonomy.py
@@ -94,6 +94,14 @@ def test_lineage_gtdb(taxonomy_ncbi_and_gtdb: Taxonomy) -> None:
     )
 
 
+def test_gtdb_root_linked_to_ncbi_root(taxonomy_ncbi_and_gtdb: Taxonomy) -> None:
+    # Check if the GTDB root is linked to the NCBI root
+    lineage = list(taxonomy_ncbi_and_gtdb.find_lineage("RS_GCF_000744315.1"))
+    identifiers = [entry.identifier for entry in lineage]
+    assert "gtdb:root" in identifiers, "GTDB root not in lineage."
+    assert "1" in identifiers, "NCBI root not in lineage."
+
+
 def test_children(taxonomy: Taxonomy) -> None:
     children = list(taxonomy.find_children("9604"))
     identifiers = {child.identifier for child in children}

--- a/tests/test_taxonomy.py
+++ b/tests/test_taxonomy.py
@@ -45,13 +45,13 @@ def test_scientific_name(taxonomy: Taxonomy) -> None:
 
 
 def test_scientific_name_gtdb(taxonomy_ncbi_and_gtdb: Taxonomy) -> None:
-    scientific_name = taxonomy_ncbi_and_gtdb.find_scientific_name("RS_GCF_009898805.1")
+    scientific_name = taxonomy_ncbi_and_gtdb.find_scientific_name("GCF_009898805.1")
     assert scientific_name == "Escherichia coli"
-    scientific_name = taxonomy_ncbi_and_gtdb.find_scientific_name("GB_GCA_036518755.1")
+    scientific_name = taxonomy_ncbi_and_gtdb.find_scientific_name("GCA_036518755.1")
     assert scientific_name == "Palsa-295 sp036518755"
-    scientific_name = taxonomy_ncbi_and_gtdb.find_scientific_name("RS_GCF_959018705.1")
+    scientific_name = taxonomy_ncbi_and_gtdb.find_scientific_name("GCF_959018705.1")
     assert scientific_name == "Methanocatella smithii"
-    scientific_name = taxonomy_ncbi_and_gtdb.find_scientific_name("GB_GCA_008080825.1")
+    scientific_name = taxonomy_ncbi_and_gtdb.find_scientific_name("GCA_008080825.1")
     assert scientific_name == "MGIIb-O2 sp002686525"
 
 
@@ -70,14 +70,14 @@ def test_lineage(taxonomy: Taxonomy) -> None:
 
 
 def test_lineage_gtdb(taxonomy_ncbi_and_gtdb: Taxonomy) -> None:
-    lineage = list(taxonomy_ncbi_and_gtdb.find_lineage("RS_GCF_000744315.1", stop_rank="class"))
+    lineage = list(taxonomy_ncbi_and_gtdb.find_lineage("GCF_000744315.1", stop_rank="class"))
     assert all(isinstance(entry, TaxonomyEntry) for entry in lineage)
     identifiers = [entry.identifier for entry in lineage]
     assert "gtdb:d__Archaea" not in identifiers, (
         "gtdb:d__Archaea in lineage although beyond stop rank."
     )
     expected = [
-        "RS_GCF_000744315.1",
+        "GCF_000744315.1",
         "gtdb:s__Methanosarcina mazei",
         "gtdb:g__Methanosarcina",
         "gtdb:f__Methanosarcinaceae",
@@ -96,7 +96,7 @@ def test_lineage_gtdb(taxonomy_ncbi_and_gtdb: Taxonomy) -> None:
 
 def test_gtdb_root_linked_to_ncbi_root(taxonomy_ncbi_and_gtdb: Taxonomy) -> None:
     # Check if the GTDB root is linked to the NCBI root
-    lineage = list(taxonomy_ncbi_and_gtdb.find_lineage("RS_GCF_000744315.1"))
+    lineage = list(taxonomy_ncbi_and_gtdb.find_lineage("GCF_000744315.1"))
     identifiers = [entry.identifier for entry in lineage]
     assert "gtdb:root" in identifiers, "GTDB root not in lineage."
     assert "1" in identifiers, "NCBI root not in lineage."
@@ -112,8 +112,8 @@ def test_children(taxonomy: Taxonomy) -> None:
 def test_children_gtdb(taxonomy_ncbi_and_gtdb: Taxonomy) -> None:
     children = list(taxonomy_ncbi_and_gtdb.find_children("gtdb:o__Acidiferrobacterales"))
     identifiers = {child.identifier for child in children}
-    assert "GB_GCA_035292245.1" in identifiers, (
-        "GB_GCA_035292245.1 assembly not in children of gtdb:o__Acidiferrobacterales."
+    assert "GCA_035292245.1" in identifiers, (
+        "GCA_035292245.1 assembly not in children of gtdb:o__Acidiferrobacterales."
     )
     assert "gtdb:f__SPGG2" in identifiers, (
         "gtdb:f__SPGG2 taxid not in children of gtdb:o__Acidiferrobacterales."


### PR DESCRIPTION
This pull request introduces support for integrating Genome Taxonomy Database (GTDB) taxonomy into the existing taxonomy database. The changes include modifications to the database creation process, additional methods for handling GTDB data, and updates to identifier handling to account for GTDB-specific prefixes.

By default, taxonomic identifiers from GTDB are prefixed with `gtdb:`. The nodes of the taxonomic tree are parsed from lineage strings in GTDB, so taxids are not numeric like in NCBI, but strings like "gtdb:d__Bacteria" or "gtdb:c__Aenigmatarchaeia".
GTDB taxonomy is linked to the taxonomic tree from NCBI using a `gtdb:root` node, linked to the root of the NCBI taxonomy (taxid 1).

GTDB prefixes the NCBI assembly accessions with "GB_" or "RS_" depending on the source database. ~I'm keeping this and thus do not overwrite the taxonomy for assemblies from NCBI.~ For compatibility, remove this prefix and overwrite taxonomic information for assemblies in GTDB. Prokaryotic assemblies that are in GTDB are linked to the GTDB taxonomy; assemblies not in GTDB keep the NCBI taxonomy.

## Changes in this PR
### GTDB Taxonomy Integration:

* **Optional GTDB Taxonomy Loading**: The `create_db` method now accepts a new parameter, `add_gtdb_taxonomy`, allowing users to optionally load GTDB taxonomy data into the database.
* **New `_add_gtdb_taxonomy` Method**: Introduced a private method `_add_gtdb_taxonomy` to handle downloading, parsing, and inserting GTDB taxonomy data into the database. This includes creating a root node for GTDB taxonomy, adding nodes and names for taxonomic ranks, and linking GTDB-specific assembly accessions.
* **Helper Methods for GTDB Data**: Added `_gtdb_add_nodes_and_names` and `_gtdb_add_assemblies` methods to process GTDB taxonomy data and update the database's `nodes`, `names`, and `assemblies` tables. These methods ensure proper integration of GTDB-specific taxonomic ranks and assembly identifiers.

### Identifier Handling Updates:

* **Support for GTDB Identifiers**: Updated the `get_identifier_type` method to recognize GTDB-specific prefixes (`gtdb:` for taxids, ~`GB_GCA_` and `RS_GCF_` for assemblies~). This ensures correct classification of GTDB data during database queries.

### Dependency Update:

* **Import `re` Module**: Added the `re` module import to support regular expression matching for validating GTDB versioning schemes.
* **Import `itertools` Module**: Added the `itertools` module import to facilitate creating successive overlapping pairs from an ordered list of ranks.

### Updates to tests:

* Add tests for GTDB taxonomy